### PR TITLE
Change include guards to #pragma once for consistency

### DIFF
--- a/src/EDF/Array.hpp
+++ b/src/EDF/Array.hpp
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SRC_EDF_ARRAY_HPP_
-#define SRC_EDF_ARRAY_HPP_
+#pragma once
 
 #include <EDF/Assert.hpp>
 
@@ -85,5 +84,3 @@ inline bool operator==( const Array<T, N>& lhs, const Array<T, N>& rhs ) {
 }
 
 } /* EDF */
-
-#endif /* SRC_EDF_ARRAY_HPP_ */

--- a/src/EDF/Assert.hpp
+++ b/src/EDF/Assert.hpp
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SRC_EDF_ASSERT_HPP_
-#define SRC_EDF_ASSERT_HPP_
+#pragma once
 
 #include <cstddef>
 #include <cstdio>
@@ -37,5 +36,3 @@
 #else
 #define EDF_ASSERTD(condition)
 #endif /* NDEBUG */
-
-#endif /* SRC_EDF_ASSERT_HPP_ */

--- a/src/EDF/Stack.hpp
+++ b/src/EDF/Stack.hpp
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SRC_EDF_STACK_HPP_
-#define SRC_EDF_STACK_HPP_
+#pragma once
 
 #include <EDF/Array.hpp>
 #include <EDF/Assert.hpp>
@@ -37,5 +36,3 @@ public:
 };
 
 } /* EDF */
-
-#endif /* SRC_EDF_STACK_HPP_ */


### PR DESCRIPTION
Including Vector.tpp was having issues when using include guards. It seems necessary to use pragma once instead